### PR TITLE
Fix link to ScopedModel in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ In this repo you can find skeletons for the following architectures.
 
 - [Redux](https://github.com/FilledStacks/flutter-architecture-skeletons/tree/master/redux_arch)
 
-- [Scoped Model](https://github.com/FilledStacks/flutter-architecture-skeletons/tree/master/scoped_model_arc)
+- [Scoped Model](https://github.com/FilledStacks/flutter-architecture-skeletons/tree/master/scopedmodel)
 
 Follow or star this repo to receive updates of when I add new skeletons.


### PR DESCRIPTION
Noticed that the link was wrong in the README. Easy enough to find anyway, but figured i might as well fix it while I was here.

Also thanks for all the tutorials and examples! I'm new to Flutter and excited about it, but finding it hard to figure out good ways to do things, sometimes because there aren't good ways, but often because there are too many ways. So I really appreciate having an opinionated perspective on things (coming from a primarily Ruby/Rails background I'm a fan of conventions)